### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "python3 edhiesive/silly_sentences.py"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # summer
+[![Run on Repl.it](https://repl.it/badge/github/ping-1000/summer)](https://repl.it/github/ping-1000/summer)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).